### PR TITLE
Fixed for PHP ~5.4 upwards Zend API change

### DIFF
--- a/fdopen.c
+++ b/fdopen.c
@@ -5,7 +5,11 @@
 #include "php.h"
 #include "php_fdopen.h"
 
+#if PHP_VERSION_ID <= 50299
 static function_entry fdopen_functions[] = {
+#else
+static zend_function_entry fdopen_functions[] = {
+#endif
     PHP_FE(fdopen, NULL)
     {NULL, NULL, NULL}
 };


### PR DESCRIPTION
See: https://bugs.php.net/bug.php?id=65563

The extension can now be compiled in latest PHP versions. Tested up to 5.5.7
